### PR TITLE
fix: update sdk docs for self hosted instance

### DIFF
--- a/src/pages/sdks/node.mdx
+++ b/src/pages/sdks/node.mdx
@@ -69,6 +69,17 @@ Initialize the SDK with your `APP_ID` and `APP_SECRET`.
 const phase = new Phase(APP_ID, APP_SECRET)
 ```
 
+<Note>
+If you are self-hosting Phase, you must also provide the protocol and host for your Phase instance:
+
+```js
+const PHASE_INSTANCE_HOST = 'https://localhost'
+
+const phase = new Phase(APP_ID, APP_SECRET, PHASE_INSTANCE_HOST)
+```
+
+</Note>
+
 ---
 
 ## Usage

--- a/src/pages/sdks/python.mdx
+++ b/src/pages/sdks/python.mdx
@@ -61,6 +61,17 @@ Initialize the SDK with your `APP_ID` and `APP_SECRET`.
 phase = Phase(APP_ID, APP_SECRET)
 ```
 
+<Note>
+If you are self-hosting Phase, you must also provide the protocol and host for your Phase instance:
+
+```python
+PHASE_INSTANCE_HOST = 'https://localhost'
+
+phase = Phase(APP_ID, APP_SECRET, PHASE_INSTANCE_HOST)
+```
+
+</Note>
+
 ---
 
 ## Usage


### PR DESCRIPTION
Adds instructions on correctly initializing the SDKs for self-hosted instances.