### PR TITLE
feat: update secrets api docs

### DIFF
--- a/src/pages/public-api/secrets.mdx
+++ b/src/pages/public-api/secrets.mdx
@@ -400,6 +400,9 @@ The secret model contains the basic key / value pairs that define your environme
                 "key": "DB_NAME",
                 "value": "postgres",
                 "comment": "primary db name",
+                "tags": [
+                    "db"
+                ],
                 "path": "/backend"
             }
         ]
@@ -452,6 +455,9 @@ The secret model contains the basic key / value pairs that define your environme
           "value": "postgres",
           "comment": "primary db name",
           "path": "/backend"
+          "tags": [
+              "db"
+          ],
         }
       ]
     })
@@ -464,9 +470,21 @@ The secret model contains the basic key / value pairs that define your environme
     </CodeGroup>
 
     ```json {{ title: 'Response' }}
-    {
-        "message": "Created 1 secret"
-    }
+    [
+        {
+            "id": "36fc2244-47f5-4ff4-8b72-deed1bf876da",
+            "key": "DB_NAME",
+            "value": "postgres",
+            "comment": "primary db name",
+            "tags": ["db"],
+            "path": "/backend",
+            "keyDigest": "2bba3630bec4829f3f98b9fd7548e4f782df43a24ba5d94c2dd80e1fe618c65e",
+            "version": 1,
+            "createdAt": "2024-02-13T13:41:45.551255Z",
+            "updatedAt": "2024-02-14T07:44:10.926591Z",
+            "environment": "af6b7a8e-c268-48c2-967c-032e86e26110",
+        }
+    ]
     ```
 
   </Col>
@@ -694,9 +712,21 @@ The secret model contains the basic key / value pairs that define your environme
     </CodeGroup>
 
     ```json {{ title: 'Response' }}
-    {
-        "message": "Updated 1 secret"
-    }
+    [
+        {
+            "id": "36fc2244-47f5-4ff4-8b72-deed1bf876da",
+            "key": "DB_NAME_POSTGRES",
+            "value": "postgres-primary",
+            "comment": "primary db name",
+            "tags": ["db"],
+            "path": "/backend/db",
+            "keyDigest": "2bba3630bec4829f3f98b9fd7548e4f782df43a24ba5d94c2dd80e1fe618c65e",
+            "version": 2,
+            "createdAt": "2024-02-13T13:41:45.551255Z",
+            "updatedAt": "2024-02-14T07:44:10.926591Z",
+            "environment": "af6b7a8e-c268-48c2-967c-032e86e26110",
+        }
+    ]
     ```
 
   </Col>


### PR DESCRIPTION
* Update example response for `POST` and `PUT`
* Add missing `tags` to example `POST` requests for Go and Ruby