### PR TITLE
fix: nomad docs authentication step

### DIFF
--- a/src/pages/integrations/platforms/hashicorp-nomad.mdx
+++ b/src/pages/integrations/platforms/hashicorp-nomad.mdx
@@ -136,19 +136,18 @@ In the following screen you will presented with a `Token Secret` which is the `C
   plaintext.
 </Note>
 
-1. Create an `role_id` and `secret_id` via the Vault CLI. See [Step 2](#step-2-setting-up-app-role-authentication-and-acl-policy) for instructions.
 
-2. Go to **Integrations** from the sidebar and click on **Add credentials** in the 'Service credentials' section
+1. Go to **Integrations** from the sidebar and click on **Add credentials** in the 'Service credentials' section
 
 ![Go to integrations](/assets/images/platform-integrations/integrations-sidebar.png)
 
 ![Add a credential](/assets/images/platform-integrations/add-credential-button.png)
 
-3. Click on **Hashicorp Nomad**
+2. Click on **Hashicorp Nomad**
 
 ![Click on Nomad](/assets/images/platform-integrations/hashicorp/nomad/nomad-create-creds-button.png)
 
-4. Enter your Nomad instance host including the port, and your `Token Secret` from the previous step. Enter a descriptive name and click **Save**
+3. Enter your Nomad instance host including the port, and your `Token Secret` from the previous step. Enter a descriptive name and click **Save**
 
 ![Input Nomad credentials](/assets/images/platform-integrations/hashicorp/nomad/nomad-input-creds.png)
 


### PR DESCRIPTION
Remove the incorrect copy paste step from vault docs