### PR TITLE
fix: remove trailing slash from OAuth callback URIs

### DIFF
--- a/src/pages/self-hosting/configuration/envars.mdx
+++ b/src/pages/self-hosting/configuration/envars.mdx
@@ -68,7 +68,7 @@ After setting up your credentials on the Google Cloud console, set the Client ID
 
 You can find instructions for setting up SSO with a GitHub OAuth App [here](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app).
 
-Set the "Authorization callback URL" for your GitHub OAuth App as `${HTTP_PROTOCOL}${HOST}/api/auth/callback/github/`.
+Set the "Authorization callback URL" for your GitHub OAuth App as `${HTTP_PROTOCOL}${HOST}/api/auth/callback/github`.
 
 Example:
 ```bash
@@ -94,7 +94,7 @@ Make sure the application has the `read_user` scope.
 
 You can use user-owned or group-owned applications to login to Phase. If you are running a self-hosted instance, you can also use an instance-wide application.
 
-Set the "callback URL" for your GitLab OAuth App as `${HTTP_PROTOCOL}${HOST}/api/auth/callback/gitlab/`.
+Set the "callback URL" for your GitLab OAuth App as `${HTTP_PROTOCOL}${HOST}/api/auth/callback/gitlab`.
 
 Example:
 ```bash


### PR DESCRIPTION
Removes the trailing slashes from the example callback URIs for GitHub and GitLab SSO