### PR TITLE
Improve self hosting docker docs

### DIFF
--- a/src/pages/self-hosting/aws.mdx
+++ b/src/pages/self-hosting/aws.mdx
@@ -132,8 +132,34 @@ You may:
 
 2. **Install Docker & Docker Compose**:
 
+   First, download the official Docker installation script:
+
    ```fish
-   sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
+   curl https://get.docker.com > install.sh && chmod +x install.sh
+   ```
+
+   We recommend reviewing the script before executing it on your system.
+
+   Install Docker and Docker Compose:
+
+   ```fish
+   sh install.sh
+   ```
+
+   Add your user to the Docker group:
+
+   ```fish
+   sudo usermod -aG docker $USER
+   ```
+
+   <Note>
+   You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
+   </Note>
+
+   Verify that Docker is running:
+
+   ```fish
+   docker ps
    ```
 
 3. **Download required configurations**:
@@ -171,7 +197,7 @@ You may:
 6. **Start services**:
 
    ```fish
-   docker-compose -f docker-compose.yml up -d
+   docker compose up -d
    ```
 
 7. You should now be able to access the Phase console at `https://your-ec2-ip-address`.

--- a/src/pages/self-hosting/azure.mdx
+++ b/src/pages/self-hosting/azure.mdx
@@ -144,8 +144,34 @@ You may:
 
 2. **Install Docker & Docker Compose**:
 
+   First, download the official Docker installation script:
+
    ```fish
-   sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
+   curl https://get.docker.com > install.sh && chmod +x install.sh
+   ```
+
+   We recommend reviewing the script before executing it on your system.
+
+   Install Docker and Docker Compose:
+
+   ```fish
+   sh install.sh
+   ```
+
+   Add your user to the Docker group:
+
+   ```fish
+   sudo usermod -aG docker $USER
+   ```
+
+   <Note>
+   You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
+   </Note>
+
+   Verify that Docker is running:
+
+   ```fish
+   docker ps
    ```
 
 3. **Download required configurations**:
@@ -183,7 +209,7 @@ You may:
 6. **Start services**:
 
    ```fish
-   docker-compose -f docker-compose.yml up -d
+   docker compose up -d
    ```
 
 7. You should now be able to access the Phase console at `https://your-vm-public-ip`.

--- a/src/pages/self-hosting/digitalocean.mdx
+++ b/src/pages/self-hosting/digitalocean.mdx
@@ -104,8 +104,34 @@ You may:
 
 2. **Install Docker & Docker Compose**:
 
+   First, download the official Docker installation script:
+
    ```fish
-   sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
+   curl https://get.docker.com > install.sh && chmod +x install.sh
+   ```
+
+   We recommend reviewing the script before executing it on your system.
+
+   Install Docker and Docker Compose:
+
+   ```fish
+   sh install.sh
+   ```
+
+   Add your user to the Docker group:
+
+   ```fish
+   sudo usermod -aG docker $USER
+   ```
+
+   <Note>
+   You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
+   </Note>
+
+   Verify that Docker is running:
+
+   ```fish
+   docker ps
    ```
 
 3. **Download required configurations**:
@@ -140,7 +166,7 @@ You may:
 6. **Start services**:
 
    ```fish
-   docker-compose -f docker-compose.yml up -d
+   docker compose up -d
    ```
 
 7. You should now be able to access the Phase console at `https://your-droplet-ip-address`.

--- a/src/pages/self-hosting/docker-compose.mdx
+++ b/src/pages/self-hosting/docker-compose.mdx
@@ -37,7 +37,7 @@ Add your user to the Docker group:
 sudo usermod -aG docker $USER
 ```
 
-You will need to log out and log back in. You may use use `Ctrl` + `D` and ssh back in.
+You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
 
 Verify that Docker is running:
 

--- a/src/pages/self-hosting/docker-compose.mdx
+++ b/src/pages/self-hosting/docker-compose.mdx
@@ -1,7 +1,7 @@
 import { Tag } from '@/components/Tag'
 
 export const description =
-  'Run Phase on your own infrastructure with docker-compose.'
+  'Run Phase on your own infrastructure with Docker Compose.'
 
 <Tag variant="small">SELF-HOSTING</Tag>
 
@@ -9,20 +9,43 @@ export const description =
 
 Learn how to set up the Phase Console using the Docker Compose template. {{ className: 'lead' }}
 
-Keep in mind the steps listed below serve as a rough outline on how to self-hosting Phase Services on your own infrastructure. 
+The steps outlined below provide a general guide for self-hosting Phase Services on your own infrastructure. 
 
-You may: 
-- Consider running the Phase Service behind a VPN or a VPC and not to expose it the internet directly. 
-- Need to set up things like TLS certificates, web application firewall, database backups and replication, DDoS protection, rate limiting, SSOs etc.
+Important considerations:
+- It's recommended to run the Phase Service behind a VPN or within a VPC, rather than exposing it directly to the internet.
+- You may need to configure additional components such as TLS certificates, web application firewalls, database backups and replication, DDoS protection, rate limiting, and SSO.
 
-## 1. Install docker on your machine
+## 1. Install Docker on your machine
+
+First, download the official Docker installation script:
 
 ```fish
-# Ubuntu
-sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
+curl https://get.docker.com > install.sh && chmod +x install.sh
 ```
 
-## 2. Download the configurations
+We recommend reviewing the script before executing it on your system.
+
+Install Docker and Docker Compose:
+
+```fish
+sh install.sh
+```
+
+Add your user to the Docker group:
+
+```fish
+sudo usermod -aG docker $USER
+```
+
+You will need to log out and log back in. You may use use `Ctrl` + `D` and ssh back in.
+
+Verify that Docker is running:
+
+```fish
+docker ps
+```
+
+## 2. Download the configuration files
 
 **.env** template:
 
@@ -30,32 +53,34 @@ sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
 wget -O .env https://raw.githubusercontent.com/phasehq/console/main/.env.example
 ```
 
-**Docker Compose template**:
+**Docker Compose** template:
 
 ```fish
 wget -O docker-compose.yml https://raw.githubusercontent.com/phasehq/console/main/docker-compose.yml
 ```
 
-**Nginx config**
+**Nginx config**:
 
 ```fish
 mkdir nginx && wget -O ./nginx/default.conf https://raw.githubusercontent.com/phasehq/console/main/nginx/default.conf
 ```
 
-**Nginx Dockerfile**
+**Nginx Dockerfile**:
 
 ```fish
-wget -O ./nginx/Dockerfile  https://raw.githubusercontent.com/phasehq/console/main/nginx/Dockerfile
+wget -O ./nginx/Dockerfile https://raw.githubusercontent.com/phasehq/console/main/nginx/Dockerfile
 ```
 
 ## 3. Update your configuration
 
-Please make changes to the `.env` file to suit your environment. Refer to the available [environment variables](/self-hosting/configuration/envars)
+Modify the `.env` file to match your environment settings. For a complete list of available options, refer to the [environment variables](/self-hosting/configuration/envars) documentation.
 
 ## 4. Start services
 
+Launch the Phase Console services:
+
 ```fish
-docker-compose up -d
+docker compose up -d
 ```
 
-Your Phase console deployment will be available at `https://localhost`. By default Phase will provision a self-signed TLS certificate using nginx. Please use a valid TLS certificate for your own domain in production.
+Your Phase Console deployment will be accessible at `https://localhost`. By default, Phase provisions a self-signed TLS certificate using Nginx. For production use, please configure a valid TLS certificate for your domain.

--- a/src/pages/self-hosting/docker-compose.mdx
+++ b/src/pages/self-hosting/docker-compose.mdx
@@ -37,7 +37,9 @@ Add your user to the Docker group:
 sudo usermod -aG docker $USER
 ```
 
+<Note>
 You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
+</Note>
 
 Verify that Docker is running:
 

--- a/src/pages/self-hosting/gcp.mdx
+++ b/src/pages/self-hosting/gcp.mdx
@@ -125,8 +125,34 @@ You may:
 
 2. **Install Docker & Docker Compose**:
 
+   First, download the official Docker installation script:
+
    ```fish
-   sudo apt update && sudo apt upgrade -y && sudo apt install -y docker-compose
+   curl https://get.docker.com > install.sh && chmod +x install.sh
+   ```
+
+   We recommend reviewing the script before executing it on your system.
+
+   Install Docker and Docker Compose:
+
+   ```fish
+   sh install.sh
+   ```
+
+   Add your user to the Docker group:
+
+   ```fish
+   sudo usermod -aG docker $USER
+   ```
+
+   <Note>
+   You will need to log out and log back in for the group changes to take effect. You may use `Ctrl + D` to log out and then SSH back in.
+   </Note>
+
+   Verify that Docker is running:
+
+   ```fish
+   docker ps
    ```
 
 3. **Download required configurations**:
@@ -164,7 +190,7 @@ You may:
 6. **Start services**:
 
    ```fish
-   docker-compose -f docker-compose.yml up -d
+   docker compose up -d
    ```
 
 7. You should now be able to access the Phase console at `https://your-instance-external-ip`.


### PR DESCRIPTION
Changes made:
- Switched docker-compose with docker compose
- Use the official docker install script
- Setup docker rootless for better security
- Updated docker compose, GCP, Azure, AWS and DigitalOcean docs.