### PR TITLE
feat: scroll active sidebar links into view if needed

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import clsx from 'clsx'
@@ -29,9 +29,28 @@ function TopLevelNavItem({ href, children }) {
 }
 
 function NavLink({ href, tag, active, isAnchorLink = false, children }) {
+  
+  const linkRef = useRef(null)
+
+  useEffect(() => {
+    if (active && linkRef.current) {
+      const link = linkRef.current;
+      const linkRect = link.getBoundingClientRect();
+
+      // Check if link is fully visible in the viewport
+      const isOutOfView =
+        linkRect.top < 0 || linkRect.bottom > window.innerHeight;
+
+      if (isOutOfView) {
+        link.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    }
+  }, [active]);
+  
   return (
     <Link
       href={href}
+      ref={linkRef}
       aria-current={active ? 'page' : undefined}
       className={clsx(
         'flex justify-between gap-2 py-1 pr-3 text-sm transition',


### PR DESCRIPTION
## Overview

Makes sure active sidebar links are scrolled into view if they are not currently visible. 

This manually compares the elements position with the window `innerHeight` to decide whether to `scrollIntoView` or not.  
Eventually we can replace this implementation with [scrollIntoViewIfNeeded](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded) once it is more widely supported

## Before

https://github.com/user-attachments/assets/f8d67105-27e9-46ba-a862-4953b42f7dec

## After

https://github.com/user-attachments/assets/556b164b-b764-4acf-96db-756700834d3a









