### PR TITLE
fix: update link to Phase Console secrets documentation

### DIFF
--- a/src/pages/self-hosting/kubernetes.mdx
+++ b/src/pages/self-hosting/kubernetes.mdx
@@ -111,7 +111,7 @@ helm repo update
 
 ### 7. Create a Kubernetes managed secret containing the Phase Console secrets
 
-Please see the [Phase Console documentation](https://docs.phase.dev/self-hosting/configuration#phase-secrets) for more information on the required secrets. 
+Please see the [Secret and deployment configuration](/self-hosting/configuration/envars) for more information on the required secrets. 
 
 Create a secret named `phase-console-secret` with the following content:
 


### PR DESCRIPTION
Fix a 404 in Kubernetes self-hosting docs.