### PR TITLE
style: enhance scrollbar styles for light and dark modes

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -12,10 +12,64 @@
 
 .not-prose {
   max-width: inherit;
-  margin-left: calc(50% - min(50%, 33rem))!important;
-  margin-right: calc(50% - min(50%, 33rem))!important;
+  margin-left: calc(50% - min(50%, 33rem)) !important;
+  margin-right: calc(50% - min(50%, 33rem)) !important;
 }
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  /* Apply globally to all scrollable areas */
+  * {
+    scrollbar-width: thin;
+  }
+  /* Default light mode */
+  html:not(.dark),
+  body:not(.dark),
+  :not(.dark) * {
+    scrollbar-color: theme('colors.neutral.300') theme('colors.neutral.100');
+  }
+
+  /* Dark mode */
+  .dark html,
+  .dark body,
+  .dark * {
+    scrollbar-color: theme('colors.zinc.700') theme('colors.zinc.900');
+  }
+
+  *::-webkit-scrollbar {
+    width: 8px;
+    background: theme('colors.neutral.100');
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background: theme('colors.neutral.300');
+    border-radius: 4px;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: theme('colors.neutral.400');
+  }
+
+  *::-webkit-scrollbar-thumb:active {
+    background: theme('colors.neutral.400');
+  }
+
+  .dark *::-webkit-scrollbar {
+    background: theme('colors.zinc.900');
+  }
+
+  .dark *::-webkit-scrollbar-thumb {
+    background: theme('colors.zinc.700');
+  }
+
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background: theme('colors.zinc.600');
+  }
+
+  .dark *::-webkit-scrollbar-thumb:active {
+    background: theme('colors.zinc.500');
+  }
+}


### PR DESCRIPTION
Improves the scrollbar styles and colors on light and dark theme, compatible with all browsers. 
![docs-ff-chrome-dark](https://github.com/user-attachments/assets/222f9f03-b30e-4e23-b995-996551f05a06)

![docs-ff-chrome-light](https://github.com/user-attachments/assets/d122f446-5455-460c-9d6a-7b6bb3b2ea1b)

Many thanks to @jeevikasirwani for the initial idea and implementation in #172 
