### PR TITLE
fix: use phaseApp Kubernetes CRD

### DIFF
--- a/src/pages/integrations/platforms/kubernetes.mdx
+++ b/src/pages/integrations/platforms/kubernetes.mdx
@@ -30,7 +30,7 @@ helm repo add phase https://helm.phase.dev && helm repo update
 Install the Phase Secrets Operator:
 
 ```fish
-helm install phase-secrets-operator phase/phase-kubernetes-operator --set image.tag=v1.2.2
+helm install phase-secrets-operator phase/phase-kubernetes-operator --set image.tag=v1.2.4
 ```
 
 <Note>

--- a/src/pages/integrations/platforms/kubernetes.mdx
+++ b/src/pages/integrations/platforms/kubernetes.mdx
@@ -82,7 +82,7 @@ metadata:
   name: example-phase-secret
   namespace: default
 spec:
-  phaseAppName: 'your-application-name' # The name of your Phase application
+  phaseApp: 'your-application-name' # The name of your Phase application
   phaseAppEnv: 'production' # OPTIONAL - The Phase App Environment to fetch secrets from
   phaseAppEnvPath: '/' # OPTIONAL Path within the Phase application environment to fetch secrets from
   phaseHost: 'https://console.phase.dev' # OPTIONAL - URL of a Phase Console instance
@@ -105,7 +105,7 @@ metadata:
   name: example-phase-secret
   namespace: default
 spec:
-  phaseAppName: 'your-application-name' # The name of your Phase application
+  phaseApp: 'your-application-name' # The name of your Phase application
   phaseAppEnv: 'production' # OPTIONAL - The Phase App Environment to fetch secrets from
   phaseAppEnvPath: 'certs/' # OPTIONAL Path within the Phase application environment to fetch secrets from
   phaseHost: 'https://console.phase.dev' # OPTIONAL - URL of a Phase Console instance
@@ -150,6 +150,9 @@ kubectl get secret my-application-secret -o yaml
 ### Properties
 
 <Properties>
+  <Property name="phaseApp" type="required">
+    The name of the Phase application to fetch secrets from.
+  </Property>
   <Property name="phaseAppEnv" type="optional">
     The Phase App Environment to fetch secrets from (e.g., dev, staging, prod).{' '}
     <b>Default</b>: `production`.

--- a/src/pages/integrations/platforms/kubernetes.mdx
+++ b/src/pages/integrations/platforms/kubernetes.mdx
@@ -82,7 +82,7 @@ metadata:
   name: example-phase-secret
   namespace: default
 spec:
-  phaseAppId: '00000000-0000-0000-0000-000000000000' # The ID of your Phase application
+  phaseAppName: 'your-application-name' # The name of your Phase application
   phaseAppEnv: 'production' # OPTIONAL - The Phase App Environment to fetch secrets from
   phaseAppEnvPath: '/' # OPTIONAL Path within the Phase application environment to fetch secrets from
   phaseHost: 'https://console.phase.dev' # OPTIONAL - URL of a Phase Console instance
@@ -105,7 +105,7 @@ metadata:
   name: example-phase-secret
   namespace: default
 spec:
-  phaseAppId: '00000000-0000-0000-0000-000000000000' # The ID of your Phase application
+  phaseAppName: 'your-application-name' # The name of your Phase application
   phaseAppEnv: 'production' # OPTIONAL - The Phase App Environment to fetch secrets from
   phaseAppEnvPath: 'certs/' # OPTIONAL Path within the Phase application environment to fetch secrets from
   phaseHost: 'https://console.phase.dev' # OPTIONAL - URL of a Phase Console instance
@@ -226,8 +226,8 @@ metadata:
   name: example-phase-secret
   namespace: default
 spec:
-  phaseAppId: '00000000-0000-0000-0000-000000000000'
-  phaseAppEnv: 'prod'
+  phaseApp: 'your-application-name'
+  phaseAppEnv: 'production'
   phaseAppEnvTag: 'certs'
   phaseHost: 'https://console.phase.dev'
   authentication:


### PR DESCRIPTION
Use `phaseApp` instead of `phaseAppId` in the Phase Kubernetes Secrets Operator's Custom Resource (CR).