### PR TITLE
fix: update environment variable name for sso providers

### DIFF
--- a/src/pages/self-hosting/configuration/envars.mdx
+++ b/src/pages/self-hosting/configuration/envars.mdx
@@ -834,6 +834,15 @@ These variables are not required if using the suggested [docker-compose template
     Required by the [`frontend`](https://hub.docker.com/r/phasehq/frontend) container.
   </Property>
   <Property name="SSO_PROVIDERS" type="string">
+    Comma-separated list of NextAuth providers.
+    
+    Example: `google,github,gitlab`
+
+    Required by the [`frontend`](https://hub.docker.com/r/phasehq/frontend) container.
+  </Property>
+  <Property name="NEXT_PUBLIC_NEXTAUTH_PROVIDERS (Legacy)" type="string">
+    **This is a legacy variable and is not required if you using Console version >= `v2.50.0`**
+
     Comma-separated list of NextAuth providers. References `${SSO_PROVIDERS}`
     
     Example: `google,github,gitlab`

--- a/src/pages/self-hosting/railway.mdx
+++ b/src/pages/self-hosting/railway.mdx
@@ -99,7 +99,7 @@ Set up a Google, GitHub or GitLab OAuth application. Please refer to the [docs](
    - Select **Variables**
    - Click **+ New Variables**
    - Add your OAuth provider's `CLIENT_ID` and `CLIENT_SECRET`
-   - You may need to set `SSO_PROVIDERS` in the `frontend` service if not done previously
+   - You may need to set `SSO_PROVIDERS` in the `frontend` service if not done previously. (Note: use the legacy `NEXT_PUBLIC_NEXTAUTH_PROVIDERS` variable if using a version of the console older than `v2.50.0`)
    - Click **Add**
 
 Here's what it looks like for the `frontend`:


### PR DESCRIPTION
`NEXT_PUBLIC_NEXTAUTH_PROVIDERS` -> `SSO_PROVIDERS`

`NEXT_PUBLIC_NEXTAUTH_PROVIDERS`  was deprecated in https://github.com/phasehq/console/pull/620