### PR TITLE
fix: correct API docs to match implementation

### DIFF
--- a/src/pages/public-api/apps.mdx
+++ b/src/pages/public-api/apps.mdx
@@ -167,7 +167,7 @@ The Apps API requires server-side encryption (SSE). Apps created via the API are
 
     </CodeGroup>
 
-    ```json {{ title: 'Response' }}
+    ```json {{ title: 'Response', statusCode: '201' }}
     {
         "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
         "name": "My New App",

--- a/src/pages/public-api/environments.mdx
+++ b/src/pages/public-api/environments.mdx
@@ -14,7 +14,7 @@ export const metadata = {
 Environments represent deployment stages within an App (e.g. Development, Staging, Production). Each Environment contains its own set of Secrets. On this page, we'll look at the Environments API endpoints for listing, creating, updating, and deleting Environments. {{ className: 'lead' }}
 
 <Note>
-The Environments API requires server-side encryption (SSE) to be enabled for the parent App. An `app_id` query parameter is required for list and create operations.
+The Environments API requires server-side encryption (SSE) to be enabled for the parent App. An `app_id` query parameter is required for list and create operations — omitting it returns `403` as the API cannot resolve the app context.
 </Note>
 
 <DocActions />
@@ -33,8 +33,8 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
   <Property name="envType" type="string">
     The type of environment: `dev`, `staging`, `prod`, or `custom`.
   </Property>
-  <Property name="app" type="object">
-    The parent app, with `id` and `name`.
+  <Property name="index" type="integer">
+    The display order index of the environment within its app.
   </Property>
   <Property name="createdAt" type="timestamp">
     Timestamp of when the environment was created.
@@ -94,10 +94,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
             "id": "af6b7a8e-c268-48c2-967c-032e86e26110",
             "name": "Development",
             "envType": "dev",
-            "app": {
-                "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-                "name": "My App"
-            },
+            "index": 0,
             "createdAt": "2024-06-01T12:00:00Z",
             "updatedAt": "2024-06-01T12:00:00Z"
         },
@@ -105,10 +102,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
             "id": "b12c3d4e-5678-90ab-cdef-1234567890ab",
             "name": "Staging",
             "envType": "staging",
-            "app": {
-                "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-                "name": "My App"
-            },
+            "index": 1,
             "createdAt": "2024-06-01T12:00:00Z",
             "updatedAt": "2024-06-01T12:00:00Z"
         },
@@ -116,10 +110,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
             "id": "c23d4e5f-6789-01bc-def2-3456789012cd",
             "name": "Production",
             "envType": "prod",
-            "app": {
-                "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-                "name": "My App"
-            },
+            "index": 2,
             "createdAt": "2024-06-01T12:00:00Z",
             "updatedAt": "2024-06-01T12:00:00Z"
         }
@@ -156,14 +147,6 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
       </Property>
     </Properties>
 
-    #### Optional fields
-
-    <Properties>
-      <Property name="env_type" type="string">
-        The environment type: `dev`, `staging`, `prod`, or `custom`. Defaults to `custom`.
-      </Property>
-    </Properties>
-
   </Col>
   <Col sticky>
 
@@ -174,8 +157,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
       -H "Authorization: Bearer {token}" \
       -H "Content-Type: application/json" \
       -d '{
-        "name": "canary",
-        "env_type": "custom"
+        "name": "canary"
       }'
     ```
 
@@ -191,8 +173,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
         'Content-Type': 'application/json'
     }
     payload = {
-        'name': 'canary',
-        'env_type': 'custom'
+        'name': 'canary'
     }
 
     response = requests.post(url, params=params, json=payload, headers=headers)
@@ -201,15 +182,12 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
 
     </CodeGroup>
 
-    ```json {{ title: 'Response' }}
+    ```json {{ title: 'Response', statusCode: '201' }}
     {
         "id": "d34e5f6a-7890-12cd-ef34-567890123456",
         "name": "canary",
         "envType": "custom",
-        "app": {
-            "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-            "name": "My App"
-        },
+        "index": 3,
         "createdAt": "2024-06-02T10:00:00Z",
         "updatedAt": "2024-06-02T10:00:00Z"
     }
@@ -265,10 +243,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
         "id": "af6b7a8e-c268-48c2-967c-032e86e26110",
         "name": "Development",
         "envType": "dev",
-        "app": {
-            "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-            "name": "My App"
-        },
+        "index": 0,
         "createdAt": "2024-06-01T12:00:00Z",
         "updatedAt": "2024-06-01T12:00:00Z"
     }
@@ -340,10 +315,7 @@ The Environments API requires server-side encryption (SSE) to be enabled for the
         "id": "af6b7a8e-c268-48c2-967c-032e86e26110",
         "name": "dev-v2",
         "envType": "dev",
-        "app": {
-            "id": "72b9ddd5-8fce-49ab-89d9-c431d53a9552",
-            "name": "My App"
-        },
+        "index": 0,
         "createdAt": "2024-06-01T12:00:00Z",
         "updatedAt": "2024-06-02T11:00:00Z"
     }

--- a/src/pages/public-api/errors.mdx
+++ b/src/pages/public-api/errors.mdx
@@ -27,17 +27,32 @@ Here is a list of the different categories of status codes returned by the Proto
   <Property name="200">
     A 200 status code indicates a successful response.
   </Property>
+  <Property name="201">
+    A 201 status code indicates a resource was successfully created (returned by POST endpoints that create apps, environments, roles, service accounts, or invites).
+  </Property>
+  <Property name="204">
+    A 204 status code indicates a successful deletion with no response body.
+  </Property>
   <Property name="400">
-    A 400 status code indicates a bad request. This is typically due to a request that's missing some data requried to process the request, such as missing `id` fields.
+    A 400 status code indicates a bad request — missing required fields, invalid field types, or validation errors.
   </Property>
   <Property name="403">
-    A 403 status code indicates an authentication or access error. Check your [authentication](/public-api#authentication) credentials if you see this error, and make sure the token you're using has the approriate scope for the App and Environment you're trying to access.
+    A 403 status code indicates an authentication or access error. Check your [authentication](/public-api#authentication) credentials if you see this error, and make sure the token you're using has the appropriate scope for the App and Environment you're trying to access.
 
-    This error may also occur due to a [Network Access Policy](/access-control/network#network-access-policies) that restricts access from your IP address. 
+    This error may also occur due to a [Network Access Policy](/access-control/network#network-access-policies) that restricts access from your IP address.
     [Read more](https://docs.phase.dev/access-control/network#access-denied-exceptions) about Network Access Policy exceptions.
   </Property>
+  <Property name="404">
+    A 404 status code indicates the requested resource was not found, or does not belong to your organisation.
+  </Property>
+  <Property name="405">
+    A 405 status code indicates the HTTP method is not supported for this endpoint (e.g. PATCH).
+  </Property>
   <Property name="409">
-    A 409 status code indicates that the requested operation will create a conflict in your secret configuration. This is generally due to attempting to set the `key` of a secret at a given path where this key already exists. 
+    A 409 status code indicates a conflict — such as a duplicate name, an existing invite for the same email, a duplicate secret key at the same path, or attempting to delete a resource that is still in use (e.g. a role with members or service accounts assigned).
+  </Property>
+  <Property name="429">
+    A 429 status code indicates you have exceeded the [rate limit](/public-api#rate-limits) for your plan. The response includes a `retry-after` header.
   </Property>
   <Property name="5xx">
     A 5xx status code indicates a server error — something went wrong with the Phase API.

--- a/src/pages/public-api/members.mdx
+++ b/src/pages/public-api/members.mdx
@@ -170,7 +170,7 @@ Organisation members are human users who belong to your Phase organisation, each
 
     </CodeGroup>
 
-    ```json {{ title: 'Response' }}
+    ```json {{ title: 'Response', statusCode: '201' }}
     {
         "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         "inviteeEmail": "bob@example.com",
@@ -262,10 +262,12 @@ Organisation members are human users who belong to your Phase organisation, each
 
     ### Constraints
 
+    - The Owner member's role cannot be changed via the API. Use the ownership transfer flow in the console.
+    - Service Account tokens cannot modify members who hold global-access roles (e.g. Admin).
     - You cannot update your own role.
-    - You cannot update a member who holds a global-access role (Owner or Admin) unless you also hold a global-access role.
-    - The Owner role cannot be assigned via this endpoint — use the ownership transfer flow in the console.
-    - Global-access roles (Admin) can only be assigned by a caller who already holds a global-access role. Service Account tokens cannot assign global-access roles.
+    - You cannot update a member who holds a global-access role unless you also hold a global-access role.
+    - The Owner role cannot be assigned to another member via this endpoint.
+    - Global-access roles (e.g. Admin) can only be assigned by a caller who already holds a global-access role. Service Account tokens cannot assign global-access roles.
 
     ### URL parameters
 
@@ -347,6 +349,8 @@ Organisation members are human users who belong to your Phase organisation, each
 
     ### Constraints
 
+    - The Owner cannot be removed via the API. Use the ownership transfer flow in the console.
+    - Service Account tokens cannot remove members who hold global-access roles (e.g. Admin).
     - You cannot remove yourself from the organisation via the API.
 
     ### URL parameters

--- a/src/pages/public-api/roles.mdx
+++ b/src/pages/public-api/roles.mdx
@@ -46,15 +46,22 @@ When fetching a single role, the full permissions object is included. The permis
 
 <Properties>
   <Property name="permissions" type="object">
-    Organisation-level permissions. Keys are resource names (e.g. `Apps`, `Members`, `Roles`), values are arrays of allowed actions (`create`, `read`, `update`, `delete`).
+    Organisation-level permissions. Keys are resource names, values are arrays of allowed actions (`create`, `read`, `update`, `delete`). Valid resources: `Apps`, `Billing`, `ExternalIdentities`, `IntegrationCredentials`, `Logs`, `MemberPersonalAccessTokens`, `Members`, `NetworkAccessPolicies`, `Organisation`, `Roles`, `ServiceAccountTokens`, `ServiceAccounts`.
   </Property>
-  <Property name="app_permissions" type="object">
-    App-level permissions. Keys are resource names (e.g. `Secrets`, `Environments`), values are arrays of allowed actions.
+  <Property name="appPermissions" type="object">
+    App-level permissions. Keys are resource names, values are arrays of allowed actions. Valid resources: `DynamicSecretLeases`, `EncryptionMode`, `Environments`, `Integrations`, `Lockbox`, `Logs`, `Members`, `Secrets`, `ServiceAccounts`, `Tokens`.
   </Property>
-  <Property name="global_access" type="boolean">
+  <Property name="globalAccess" type="boolean">
     Whether the role grants global access to all Apps and Environments.
   </Property>
+  <Property name="meta" type="object">
+    Metadata with `version` (integer) and `description` (string). Present only on default roles (Owner, Admin, Manager, Developer, Service). Not included for custom roles.
+  </Property>
 </Properties>
+
+<Note>
+Responses use camelCase keys (`appPermissions`, `globalAccess`). When sending permissions on POST or PUT, both camelCase and snake_case (`app_permissions`, `global_access`) are accepted.
+</Note>
 
 ---
 
@@ -172,21 +179,37 @@ When fetching a single role, the full permissions object is included. The permis
         "isDefault": true,
         "createdAt": "2024-01-01T00:00:00Z",
         "permissions": {
+            "meta": {
+                "version": 1,
+                "description": "Development users with limited organisation-level permissions. Requires explicit access to Apps and Environments."
+            },
             "permissions": {
                 "Organisation": [],
                 "Billing": [],
                 "Apps": ["read"],
                 "Members": ["read"],
+                "MemberPersonalAccessTokens": [],
                 "ServiceAccounts": [],
-                "Roles": ["read"]
+                "ServiceAccountTokens": [],
+                "ExternalIdentities": [],
+                "Roles": ["read"],
+                "IntegrationCredentials": ["create", "read", "update"],
+                "NetworkAccessPolicies": ["read"],
+                "Logs": ["read"]
             },
-            "app_permissions": {
+            "appPermissions": {
                 "Environments": ["read", "create", "update"],
                 "Secrets": ["create", "read", "update", "delete"],
+                "DynamicSecretLeases": ["create", "read"],
+                "Lockbox": ["create", "read", "update", "delete"],
+                "Logs": ["read"],
                 "Tokens": ["read", "create"],
-                "Members": ["read"]
+                "Members": ["read"],
+                "ServiceAccounts": ["create"],
+                "Integrations": ["create", "read", "update", "delete"],
+                "EncryptionMode": ["read", "update"]
             },
-            "global_access": false
+            "globalAccess": false
         }
     }
     ```
@@ -293,7 +316,7 @@ When fetching a single role, the full permissions object is included. The permis
 
     </CodeGroup>
 
-    ```json {{ title: 'Response' }}
+    ```json {{ title: 'Response', statusCode: '201' }}
     {
         "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
         "name": "Read Only",
@@ -308,11 +331,11 @@ When fetching a single role, the full permissions object is included. The permis
                 "Members": ["read"],
                 "Roles": ["read"]
             },
-            "app_permissions": {
+            "appPermissions": {
                 "Secrets": ["read"],
                 "Environments": ["read"]
             },
-            "global_access": false
+            "globalAccess": false
         }
     }
     ```
@@ -328,6 +351,11 @@ When fetching a single role, the full permissions object is included. The permis
   <Col>
 
     Update a custom role's name, description, color, and/or permissions. At least one field must be provided. Default roles cannot be modified.
+
+    ### Constraints
+
+    - Default roles cannot be modified.
+    - If updating `permissions` to enable `global_access`, the role must not have any service accounts assigned to it.
 
     ### URL parameters
 
@@ -420,12 +448,12 @@ When fetching a single role, the full permissions object is included. The permis
                 "Roles": ["read"],
                 "ServiceAccounts": ["read"]
             },
-            "app_permissions": {
+            "appPermissions": {
                 "Secrets": ["read"],
                 "Environments": ["read"],
                 "Logs": ["read"]
             },
-            "global_access": false
+            "globalAccess": false
         }
     }
     ```

--- a/src/pages/public-api/service-accounts.mdx
+++ b/src/pages/public-api/service-accounts.mdx
@@ -171,7 +171,7 @@ When fetching a single service account, additional detail fields are included:
 
     </CodeGroup>
 
-    ```json {{ title: 'Response' }}
+    ```json {{ title: 'Response', statusCode: '201' }}
     {
         "id": "8ab27128-02d8-42c1-b893-12acaffbbd4b",
         "name": "deploy-bot",


### PR DESCRIPTION
## Summary

Fixes documentation mismatches found during black-box validation of the REST API management endpoints.

## Changes

### environments.mdx
- Remove `env_type` from POST request body — backend hardcodes `"custom"`, field is ignored
- Remove `app` object from response model — serializer does not include it
- Add `index` (integer) to response model and all response examples
- Note that omitting `app_id` returns 403 (auth layer cannot resolve app context)

### members.mdx
- Document Owner immutability: role cannot be changed and member cannot be removed via the API
- Document SA restriction: service accounts cannot modify or remove global-access members
- Fix invite response status code to 201

### roles.mdx
- Fix response examples to use camelCase (`appPermissions`, `globalAccess`) matching actual output
- Add note that input accepts both camelCase and snake_case
- List all valid org-level (12) and app-level (10) permission resource classes
- Document role update constraint: cannot enable `global_access` when SAs are assigned

### apps.mdx
- Fix create response status code to 201

### service-accounts.mdx
- Fix create response status code to 201

### errors.mdx
- Add missing status codes: 201, 204, 404, 405, 429
- Expand 400 and 409 descriptions