### PR TITLE
docs: add direct .exe download for Windows CLI install

### DIFF
--- a/src/pages/cli/install.mdx
+++ b/src/pages/cli/install.mdx
@@ -37,9 +37,19 @@ curl -fsSL https://pkg.phase.dev/install.sh | sh
 # curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version 2.0.0
 ```
 
-```fish {{ title: 'Windows' }}
+```fish {{ title: 'Scoop' }}
 scoop bucket add phasehq https://github.com/phasehq/scoop-cli.git
 scoop install phase
+```
+
+```fish {{ title: 'Windows (.exe)' }}
+# Download the latest .exe for your architecture from:
+# https://github.com/phasehq/cli/releases/latest
+#
+#   phase_cli_<version>_windows_amd64.exe   (Intel / AMD 64-bit)
+#   phase_cli_<version>_windows_arm64.exe   (ARM 64-bit)
+#
+# Rename to phase.exe and add it to a directory on your PATH.
 ```
 
 ```fish {{ title: 'Alpine Linux' }}
@@ -73,8 +83,14 @@ brew update && brew upgrade phase
 phase update
 ```
 
-```fish {{ title: 'Windows' }}
+```fish {{ title: 'Scoop' }}
 scoop update phase
+```
+
+```fish {{ title: 'Windows (.exe)' }}
+# Re-download the latest .exe from:
+# https://github.com/phasehq/cli/releases/latest
+# and replace your existing phase.exe.
 ```
 
 ```fish {{ title: 'Alpine Linux' }}

--- a/src/pages/quickstart.mdx
+++ b/src/pages/quickstart.mdx
@@ -42,9 +42,19 @@ brew install phasehq/cli/phase
 curl -fsSL https://pkg.phase.dev/install.sh | bash
 ```
 
-```fish {{ title: 'Windows' }}
+```fish {{ title: 'Scoop' }}
 scoop bucket add phasehq https://github.com/phasehq/scoop-cli.git
 scoop install phase
+```
+
+```fish {{ title: 'Windows (.exe)' }}
+# Download the latest .exe for your architecture from:
+# https://github.com/phasehq/cli/releases/latest
+#
+#   phase_cli_<version>_windows_amd64.exe   (Intel / AMD 64-bit)
+#   phase_cli_<version>_windows_arm64.exe   (ARM 64-bit)
+#
+# Rename to phase.exe and add it to a directory on your PATH.
 ```
 
 ```fish {{ title: 'Alpine Linux' }}


### PR DESCRIPTION
Splits the previous Windows tab into a Scoop tab and a new Windows (.exe) tab pointing at the GitHub Releases binaries for users without Scoop.