### PR TITLE
fix:  document SCIM provisioning edge case, fix hydration error

### DIFF
--- a/public/access-control/provisioning/scim.md
+++ b/public/access-control/provisioning/scim.md
@@ -31,6 +31,12 @@ When SCIM is enabled, your identity provider communicates with Phase's SCIM v2 A
 3. **User completes account setup** → User sets up their sudo password and recovery phrase, enabling them to decrypt secrets
 4. **IdP unassigns user** → SCIM deactivates the user, revokes environment keys, and removes them from the organisation
 
+<Warning>
+  **Limitation: users with an existing Phase identity**
+
+  To prevent account takeover, Phase won't silently link a SCIM-provisioned account to an existing Phase user who already has a password, a linked SSO / social login, or an active membership in another organisation. The provision succeeds and the user appears under **Members** with `SCIM` and `Pending` badges, but their first SSO login to the new organisation is refused. A consent-based linking flow is planned as a follow-up.
+</Warning>
+
 ## Enable SCIM in Phase
 
 Before configuring your identity provider, enable SCIM in the Phase Console and create a provisioning token:

--- a/src/components/mdx.jsx
+++ b/src/components/mdx.jsx
@@ -1,3 +1,4 @@
+import { isValidElement } from 'react'
 import Link from 'next/link'
 import clsx from 'clsx'
 
@@ -120,7 +121,22 @@ export function MathSymbol({ children }) {
   return (<span className="font-serif font-semibold italic">{children}</span>)
 }
 
-export const img = (props) => (
-  <ZoomableImage {...props} width={props.width || 800} height={props.height || 600} />
-);
+export const img = function Img(props) {
+  return <ZoomableImage {...props} width={props.width || 800} height={props.height || 600} />
+}
+
+export const p = function P({ children, ...rest }) {
+  const arr = Array.isArray(children) ? children : [children]
+  const meaningful = arr.filter(
+    (c) => !(typeof c === 'string' && c.trim() === '')
+  )
+  if (
+    meaningful.length === 1 &&
+    isValidElement(meaningful[0]) &&
+    meaningful[0].type === img
+  ) {
+    return meaningful[0]
+  }
+  return <p {...rest}>{children}</p>
+}
 

--- a/src/pages/access-control/provisioning/scim.mdx
+++ b/src/pages/access-control/provisioning/scim.mdx
@@ -31,6 +31,12 @@ When SCIM is enabled, your identity provider communicates with Phase's SCIM v2 A
 3. **User completes account setup** → User sets up their sudo password and recovery phrase, enabling them to decrypt secrets
 4. **IdP unassigns user** → SCIM deactivates the user, revokes environment keys, and removes them from the organisation
 
+<Warning>
+  **Limitation: users with an existing Phase identity**
+
+  To prevent account takeover, Phase won't silently link a SCIM-provisioned account to an existing Phase user who already has a password, a linked SSO / social login, or an active membership in another organisation. The provision succeeds and the user appears under **Members** with `SCIM` and `Pending` badges, but their first SSO login to the new organisation is refused. A consent-based linking flow is planned as a follow-up.
+</Warning>
+
 ## Enable SCIM in Phase
 
 Before configuring your identity provider, enable SCIM in the Phase Console and create a provisioning token:


### PR DESCRIPTION
* added a note to document an edge case when SCIM provisioning existing user emails
* fix the way markdown imgs are rendered to prevent `div` tags inside `p` tags that were causing a number of hydration errors