### PR TITLE
docs(rest): align Roles 'global_access' usage and DELETE-SA token-invalidation status with backend

### DIFF
--- a/src/pages/public-api/roles.mdx
+++ b/src/pages/public-api/roles.mdx
@@ -222,7 +222,7 @@ Responses use camelCase keys (`appPermissions`, `globalAccess`). On POST and PUT
         The role name. Maximum 64 characters. Must be unique within the organisation (case-insensitive).
       </Property>
       <Property name="permissions" type="object">
-        The permissions object. Must include `permissions` (org-level), `app_permissions` (app-level), and `global_access` (boolean).
+        The permissions object. Must contain exactly two keys: `permissions` (org-level) and `app_permissions` (app-level). The `global_access` flag cannot be set on custom roles — POST and PUT reject requests that include `global_access` (or `globalAccess`) under `permissions` with `400 Bad Request`.
       </Property>
     </Properties>
 
@@ -260,8 +260,7 @@ Responses use camelCase keys (`appPermissions`, `globalAccess`). On POST and PUT
           "app_permissions": {
             "Secrets": ["read"],
             "Environments": ["read"]
-          },
-          "global_access": false
+          }
         }
       }'
     ```
@@ -289,7 +288,6 @@ Responses use camelCase keys (`appPermissions`, `globalAccess`). On POST and PUT
                 'Secrets': ['read'],
                 'Environments': ['read'],
             },
-            'global_access': False,
         }
     }
 
@@ -345,7 +343,7 @@ Responses use camelCase keys (`appPermissions`, `globalAccess`). On POST and PUT
 
     ### JSON Body
 
-    When `permissions` is provided, the full object replaces the stored permissions and must contain all three keys: `permissions`, `app_permissions`, and `global_access`. The camelCase variants `appPermissions` and `globalAccess` are also accepted on input.
+    When `permissions` is provided, the full object replaces the stored permissions and must contain exactly two keys: `permissions` and `app_permissions`. The camelCase variant `appPermissions` is also accepted on input. Sending `global_access` (or `globalAccess`) under `permissions` returns `400 Bad Request`.
 
     <Properties>
       <Property name="name" type="string">
@@ -386,8 +384,7 @@ Responses use camelCase keys (`appPermissions`, `globalAccess`). On POST and PUT
             "Secrets": ["read"],
             "Environments": ["read"],
             "Logs": ["read"]
-          },
-          "global_access": false
+          }
         }
       }'
     ```

--- a/src/pages/public-api/service-accounts.mdx
+++ b/src/pages/public-api/service-accounts.mdx
@@ -377,7 +377,7 @@ When fetching a single service account, additional detail fields are included:
 <Row>
   <Col>
 
-    Delete a service account. All associated tokens are immediately invalidated (subsequent requests with those tokens return `403 Forbidden`), and all app/environment access grants are removed.
+    Delete a service account. All associated tokens are immediately invalidated (subsequent requests with those tokens return `401 Unauthorized` with `{"error": "Token expired or deleted"}`), and all app/environment access grants are removed.
 
     ### URL parameters
 


### PR DESCRIPTION
## Summary

Two small corrections found while re-validating the merged feature branch against the current backend (`phasehq/console@api--apps-envs-accounts`). Stacks under #213.

### Roles — request examples sent a rejected key
The POST/PUT examples in `roles.mdx` shipped `"global_access": false` inside `permissions`. The server unconditionally rejects this:

```python
# backend/api/views/roles.py:58
allowed_keys = {"permissions", "app_permissions"}
# → 400 "Unknown top-level keys: global_access. Allowed keys: permissions, app_permissions."
```

Copy-pasting the docs' cURL or Python snippet failed with 400. Also reconciled the Required-fields / PUT-body prose, which previously said `global_access` was required — the Note at the top of the page already correctly said only `permissions` + `app_permissions` are accepted, so the page now reads consistently.

### Service Accounts — DELETE-SA paragraph cited the wrong status code
*Delete Service Account* said revoked tokens return `403 Forbidden`. Actual behaviour is `401 Unauthorized`:

```python
# backend/api/auth.py:88-89
if token_is_expired_or_deleted(auth_token):
    raise exceptions.AuthenticationFailed("Token expired or deleted")
# → DRF maps AuthenticationFailed to 401
```

This matches the sibling *Delete Token* paragraph (already says 401) and `errors.mdx:40`. Single-line fix.

## Follow-up worth tracking separately (not in this PR)

- **Custom-role response omits `globalAccess`.** Per Rohan's comment on PH-618 (May 25), the intent is for `globalAccess` to be returned on *all* role responses, including custom roles. Current code only returns it for built-in defaults — verified again today against the dev backend:
  ```
  GET /v1/roles/<custom-id>/  →
  {
    ...
    "permissions": {
      "permissions": {...},
      "appPermissions": {...}
      // no "globalAccess" key
    }
  }
  ```
  The doc examples (POST/PUT response, lines 321 + 436) still show `"globalAccess": false` on custom roles, which matches Rohan's stated intent. Leaving them unchanged here so the docs reflect intended behaviour; needs a backend tweak so the response actually includes it.

- **`POST /v1/environments` returns 400, `PUT` returns 409 for the same "name already exists" condition** — same error string, different status. Backend fix, not docs. `backend/api/utils/environments.py:239` raises `ValueError`; the POST handler at `backend/api/views/environments.py:130-134` blanket-converts to 400, while the PUT handler at line 280 hard-codes 409. 409 is consistent with the Roles duplicate-name behaviour. Will open a separate console PR.

## Test plan

- [ ] `roles.mdx` POST cURL example POSTs cleanly against `https://localhost/service/public/v1/roles/` (returns 201)
- [ ] `roles.mdx` PUT cURL example PUTs cleanly against an existing custom role (returns 200)
- [ ] `service-accounts.mdx` DELETE paragraph now matches `errors.mdx` 401 contract
- [ ] No other occurrences of `global_access` left in `roles.mdx` request payloads (`grep -n 'global_access' src/pages/public-api/roles.mdx` → only descriptive prose, no example keys)

Related: phasehq/console#798, PH-618