### PR TITLE
fix: k8s self hosting password auth

### DIFF
--- a/public/access-control/authentication.md
+++ b/public/access-control/authentication.md
@@ -22,7 +22,7 @@ User authentication in Phase is designed for seamless and secure web access. Pha
 
 ### Password Authentication
 
-Email and password authentication is available out of the box on Phase Cloud. On self-hosted deployments it is opt-in via [`ENABLE_PASSWORD_AUTH`](/self-hosting/configuration/envars#password-authentication); instances default to SSO-only mode. Users can sign up with their email address and a password, verify their email, and log in.
+Email and password authentication is available out of the box on Phase Cloud, and on self-hosted deployments using the official Helm chart or docker-compose template. Users can sign up with their email address and a password, verify their email, and log in.
 
 
 <div className="not-prose">

--- a/public/access-control/authentication/password.md
+++ b/public/access-control/authentication/password.md
@@ -11,9 +11,6 @@ Phase supports native email and password authentication out of the box, with no 
 
 <DocActions />
 
-<Note>
-On self-hosted deployments, password authentication is **opt-in**. Operators must set `ENABLE_PASSWORD_AUTH=true` to expose password sign-up and login; instances default to SSO-only mode. See [`ENABLE_PASSWORD_AUTH`](/self-hosting/configuration/envars#password-authentication) in the self-hosting reference.
-</Note>
 
 ## Signup
 

--- a/public/self-hosting/aws-eks.md
+++ b/public/self-hosting/aws-eks.md
@@ -407,18 +407,7 @@ phaseSecrets: phase-console-secret
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
+  annotations: {}
 
 certManager:
   enabled: true
@@ -516,18 +505,7 @@ podDisruptionBudget:
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
+  annotations: {}
 
 certManager:
   enabled: true

--- a/public/self-hosting/configuration/envars.md
+++ b/public/self-hosting/configuration/envars.md
@@ -352,7 +352,7 @@ Env(s) required by the following containers:
 
 ## Password authentication
 
-Password authentication is **opt-in** for self-hosted instances. By default, Phase runs in SSO-only mode: password signup, login, change-password and password-based recovery are refused, and the login page hides the password UI. Set `ENABLE_PASSWORD_AUTH=true` to allow password sign-up and login alongside SSO.
+Password authentication is controlled by the `ENABLE_PASSWORD_AUTH` variable. The official Helm chart and [docker-compose template](https://raw.githubusercontent.com/phasehq/console/main/docker-compose.yml) **enable it by default**, so a standard self-hosted install has password sign-up and login working out of the box alongside any configured SSO. When the variable is unset, the application falls back to SSO-only mode: password signup, login, change-password and password-based recovery are refused, and the login page hides the password UI. Set `ENABLE_PASSWORD_AUTH=false` to run an SSO-only instance.
 
 <Properties>
   <Property name="ENABLE_PASSWORD_AUTH" type="boolean (Optional)">
@@ -373,7 +373,7 @@ Password authentication is **opt-in** for self-hosted instances. By default, Pha
 </Properties>
 
 <Note>
-Before enabling SSO-only mode (i.e. leaving `ENABLE_PASSWORD_AUTH` unset on an instance that previously had password users), make sure every member who needs continued access has signed in via SSO at least once -- the SocialAccount link is created on first SSO sign-in, and existing password users will otherwise be locked out. Configure at least one provider in [`SSO_PROVIDERS`](#additional-environment-variables) before disabling password auth, otherwise the instance will have no usable sign-in path.
+Before enabling SSO-only mode (i.e. setting `ENABLE_PASSWORD_AUTH=false`, or leaving it unset, on an instance that previously had password users), make sure every member who needs continued access has signed in via SSO at least once -- the SocialAccount link is created on first SSO sign-in, and existing password users will otherwise be locked out. Configure at least one provider in [`SSO_PROVIDERS`](#additional-environment-variables) before disabling password auth, otherwise the instance will have no usable sign-in path.
 </Note>
 
 ### Email verification

--- a/public/self-hosting/kubernetes.md
+++ b/public/self-hosting/kubernetes.md
@@ -140,18 +140,6 @@ phaseSecrets: phase-console-secret # 👈 The name of the secret you have create
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
   annotations: {}
 
 certManager:
@@ -286,7 +274,7 @@ dig A phase.your-domain.com
 3. Describe the Certificate resource to check its status and events:
 
 ```fish
-kubectl describe certificate phase-tls -n your-phase-namespace # Replace with the namespace phase is installed in
+kubectl describe certificate phase-console-tls -n your-phase-namespace # Replace with the namespace phase is installed in
 ```
 
 4. Check NGINX Ingress controller logs in the `ingress-nginx` namespace.

--- a/src/pages/access-control/authentication/index.mdx
+++ b/src/pages/access-control/authentication/index.mdx
@@ -22,7 +22,7 @@ User authentication in Phase is designed for seamless and secure web access. Pha
 
 ### Password Authentication
 
-Email and password authentication is available out of the box on Phase Cloud. On self-hosted deployments it is opt-in via [`ENABLE_PASSWORD_AUTH`](/self-hosting/configuration/envars#password-authentication); instances default to SSO-only mode. Users can sign up with their email address and a password, verify their email, and log in.
+Email and password authentication is available out of the box on Phase Cloud, and on self-hosted deployments using the official Helm chart or docker-compose template. Users can sign up with their email address and a password, verify their email, and log in.
 
 
 <div className="not-prose">

--- a/src/pages/access-control/authentication/password.mdx
+++ b/src/pages/access-control/authentication/password.mdx
@@ -11,9 +11,6 @@ Phase supports native email and password authentication out of the box, with no 
 
 <DocActions />
 
-<Note>
-On self-hosted deployments, password authentication is **opt-in**. Operators must set `ENABLE_PASSWORD_AUTH=true` to expose password sign-up and login; instances default to SSO-only mode. See [`ENABLE_PASSWORD_AUTH`](/self-hosting/configuration/envars#password-authentication) in the self-hosting reference.
-</Note>
 
 ## Signup
 

--- a/src/pages/self-hosting/aws-eks.mdx
+++ b/src/pages/self-hosting/aws-eks.mdx
@@ -407,18 +407,7 @@ phaseSecrets: phase-console-secret
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
+  annotations: {}
 
 certManager:
   enabled: true
@@ -516,18 +505,7 @@ podDisruptionBudget:
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
+  annotations: {}
 
 certManager:
   enabled: true

--- a/src/pages/self-hosting/configuration/envars.mdx
+++ b/src/pages/self-hosting/configuration/envars.mdx
@@ -352,7 +352,7 @@ Env(s) required by the following containers:
 
 ## Password authentication
 
-Password authentication is **opt-in** for self-hosted instances. By default, Phase runs in SSO-only mode: password signup, login, change-password and password-based recovery are refused, and the login page hides the password UI. Set `ENABLE_PASSWORD_AUTH=true` to allow password sign-up and login alongside SSO.
+Password authentication is controlled by the `ENABLE_PASSWORD_AUTH` variable. The official Helm chart and [docker-compose template](https://raw.githubusercontent.com/phasehq/console/main/docker-compose.yml) **enable it by default**, so a standard self-hosted install has password sign-up and login working out of the box alongside any configured SSO. When the variable is unset, the application falls back to SSO-only mode: password signup, login, change-password and password-based recovery are refused, and the login page hides the password UI. Set `ENABLE_PASSWORD_AUTH=false` to run an SSO-only instance.
 
 <Properties>
   <Property name="ENABLE_PASSWORD_AUTH" type="boolean (Optional)">
@@ -373,7 +373,7 @@ Password authentication is **opt-in** for self-hosted instances. By default, Pha
 </Properties>
 
 <Note>
-Before enabling SSO-only mode (i.e. leaving `ENABLE_PASSWORD_AUTH` unset on an instance that previously had password users), make sure every member who needs continued access has signed in via SSO at least once -- the SocialAccount link is created on first SSO sign-in, and existing password users will otherwise be locked out. Configure at least one provider in [`SSO_PROVIDERS`](#additional-environment-variables) before disabling password auth, otherwise the instance will have no usable sign-in path.
+Before enabling SSO-only mode (i.e. setting `ENABLE_PASSWORD_AUTH=false`, or leaving it unset, on an instance that previously had password users), make sure every member who needs continued access has signed in via SSO at least once -- the SocialAccount link is created on first SSO sign-in, and existing password users will otherwise be locked out. Configure at least one provider in [`SSO_PROVIDERS`](#additional-environment-variables) before disabling password auth, otherwise the instance will have no usable sign-in path.
 </Note>
 
 ### Email verification

--- a/src/pages/self-hosting/kubernetes.mdx
+++ b/src/pages/self-hosting/kubernetes.mdx
@@ -140,18 +140,6 @@ phaseSecrets: phase-console-secret # 👈 The name of the secret you have create
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: phase.your-domain.com # 👈 Replace with your domain
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - phase.your-domain.com # 👈 Replace with your domain
-      secretName: phase-tls
   annotations: {}
 
 certManager:
@@ -286,7 +274,7 @@ dig A phase.your-domain.com
 3. Describe the Certificate resource to check its status and events:
 
 ```fish
-kubectl describe certificate phase-tls -n your-phase-namespace # Replace with the namespace phase is installed in
+kubectl describe certificate phase-console-tls -n your-phase-namespace # Replace with the namespace phase is installed in
 ```
 
 4. Check NGINX Ingress controller logs in the `ingress-nginx` namespace.


### PR DESCRIPTION
- Fixed: Kubernetes Helm chart deployment instructions - EKS and vanilla
- Fixed: Notes and descriptions for password auth in docs