### PR TITLE
docs: standardize CLI install commands across CI integrations

### DIFF
--- a/public/integrations/platforms/aws-codebuild.md
+++ b/public/integrations/platforms/aws-codebuild.md
@@ -31,13 +31,15 @@ For detailed cli install options, please see: [Installation](/cli/install)
 4. Use `PHASE_SERVICE_TOKEN` as the name and provide its value. Remember the parameter type and KMS key if you use one.
 5. In CodeBuild, grant permission to the service role to access this SSM parameter.
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 version: 0.2
 
 phases:
   pre_build:
     commands:
-      - curl -fsSL https://pkg.phase.dev/install.sh | bash
+      - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
   build:
     commands:

--- a/public/integrations/platforms/azure-pipelines.md
+++ b/public/integrations/platforms/azure-pipelines.md
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 trigger:
   - master
@@ -44,7 +46,7 @@ stages:
     jobs:
       - job: Prepare
         steps:
-          - script: curl -fsSL https://pkg.phase.dev/install.sh | bash
+          - script: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
             displayName: 'Install phase-cli'
           - script: |
               echo "##vso[task.setvariable variable=DOCKERHUB_USERNAME;]$(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME | cut -d '=' -f2)"

--- a/public/integrations/platforms/bitbucket-pipelines.md
+++ b/public/integrations/platforms/bitbucket-pipelines.md
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 image: atlassian/default-image:2
 
@@ -40,7 +42,7 @@ pipelines:
     - step:
         name: Prepare
         script:
-          - curl -fsSL https://pkg.phase.dev/install.sh | bash
+          - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
           - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
     - step:
         name: Build and Push

--- a/public/integrations/platforms/buildkite.md
+++ b/public/integrations/platforms/buildkite.md
@@ -33,11 +33,13 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 In your `pipeline.yml`:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 steps:
   - label: 'Prepare'
     command:
-      - 'curl -fsSL https://pkg.phase.dev/install.sh | bash'
+      - 'curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>'
       - 'export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)'
 
   - label: 'Build and Push'

--- a/public/integrations/platforms/circleci.md
+++ b/public/integrations/platforms/circleci.md
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 version: 2.1
 
@@ -43,7 +45,7 @@ jobs:
       - checkout
       - run:
           name: Install phase-cli
-          command: curl -fsSL https://pkg.phase.dev/install.sh | bash
+          command: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - run:
           name: Export and set environment variables
           command: |

--- a/public/integrations/platforms/drone-ci.md
+++ b/public/integrations/platforms/drone-ci.md
@@ -30,6 +30,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Single staged
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 kind: pipeline
 name: default
@@ -38,7 +40,7 @@ steps:
   - name: prepare
     image: alpine:latest
     commands:
-      - curl -fsSL https://pkg.phase.dev/install.sh | bash
+      - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
   - name: build_and_push

--- a/public/integrations/platforms/github-actions.md
+++ b/public/integrations/platforms/github-actions.md
@@ -329,6 +329,8 @@ For detailed CLI installation options, please see: [Installation](/cli/install)
 
 ### Single stage
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases). The install script self-elevates when needed, so `sudo` isn't required.
+
 ```yaml
 name: CI
 
@@ -343,7 +345,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install phase-cli
-        run: curl -fsSL https://pkg.phase.dev/install.sh | sudo bash
+        run: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
 
       - name: Export and set environment variables
         env:

--- a/public/integrations/platforms/gitlab-ci.md
+++ b/public/integrations/platforms/gitlab-ci.md
@@ -196,6 +196,8 @@ For detailed CLI install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 stages:
   - prepare
@@ -204,7 +206,7 @@ stages:
 prepare_phase_cli:
   stage: prepare
   script:
-    - curl -fsSL https://pkg.phase.dev/install.sh | bash
+    - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
     - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
 build_and_push_image:

--- a/public/integrations/platforms/teamcity.md
+++ b/public/integrations/platforms/teamcity.md
@@ -34,14 +34,14 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 Create a TeamCity build configuration and add the following build steps:
 
-Create a TeamCity build configuration and add the following build steps:
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
 
 1. **Prepare (Command Line Runner)**:
 
    - Run: `Custom script`
    - Custom script:
      ```fish
-     curl -fsSL https://pkg.phase.dev/install.sh | bash
+     curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
      export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
      ```
 

--- a/public/integrations/platforms/travis-ci.md
+++ b/public/integrations/platforms/travis-ci.md
@@ -31,6 +31,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 language: minimal
 
@@ -38,7 +40,7 @@ jobs:
   include:
     - stage: prepare
       script:
-        - curl -fsSL https://pkg.phase.dev/install.sh | bash
+        - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
         - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
     - stage: build_and_push

--- a/public/quickstart.md
+++ b/public/quickstart.md
@@ -39,7 +39,7 @@ brew install phasehq/cli/phase
 ```
 
 ```fish {{ title: 'Linux' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'Scoop' }}
@@ -58,7 +58,7 @@ scoop install phase
 ```
 
 ```fish {{ title: 'Alpine Linux' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'NixOS' }}
@@ -77,11 +77,11 @@ docker run phasehq/cli
 ```
 
 ```fish {{ title: 'Raspberry Pi' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'ARM64' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 </CodeGroup>

--- a/src/pages/integrations/platforms/aws-codebuild.mdx
+++ b/src/pages/integrations/platforms/aws-codebuild.mdx
@@ -31,13 +31,15 @@ For detailed cli install options, please see: [Installation](/cli/install)
 4. Use `PHASE_SERVICE_TOKEN` as the name and provide its value. Remember the parameter type and KMS key if you use one.
 5. In CodeBuild, grant permission to the service role to access this SSM parameter.
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 version: 0.2
 
 phases:
   pre_build:
     commands:
-      - curl -fsSL https://pkg.phase.dev/install.sh | bash
+      - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
   build:
     commands:

--- a/src/pages/integrations/platforms/azure-pipelines.mdx
+++ b/src/pages/integrations/platforms/azure-pipelines.mdx
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 trigger:
   - master
@@ -44,7 +46,7 @@ stages:
     jobs:
       - job: Prepare
         steps:
-          - script: curl -fsSL https://pkg.phase.dev/install.sh | bash
+          - script: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
             displayName: 'Install phase-cli'
           - script: |
               echo "##vso[task.setvariable variable=DOCKERHUB_USERNAME;]$(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME | cut -d '=' -f2)"

--- a/src/pages/integrations/platforms/bitbucket-pipelines.mdx
+++ b/src/pages/integrations/platforms/bitbucket-pipelines.mdx
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 image: atlassian/default-image:2
 
@@ -40,7 +42,7 @@ pipelines:
     - step:
         name: Prepare
         script:
-          - curl -fsSL https://pkg.phase.dev/install.sh | bash
+          - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
           - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
     - step:
         name: Build and Push

--- a/src/pages/integrations/platforms/buildkite.mdx
+++ b/src/pages/integrations/platforms/buildkite.mdx
@@ -33,11 +33,13 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 In your `pipeline.yml`:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 steps:
   - label: 'Prepare'
     command:
-      - 'curl -fsSL https://pkg.phase.dev/install.sh | bash'
+      - 'curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>'
       - 'export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)'
 
   - label: 'Build and Push'

--- a/src/pages/integrations/platforms/circleci.mdx
+++ b/src/pages/integrations/platforms/circleci.mdx
@@ -32,6 +32,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 version: 2.1
 
@@ -43,7 +45,7 @@ jobs:
       - checkout
       - run:
           name: Install phase-cli
-          command: curl -fsSL https://pkg.phase.dev/install.sh | bash
+          command: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - run:
           name: Export and set environment variables
           command: |

--- a/src/pages/integrations/platforms/drone-ci.mdx
+++ b/src/pages/integrations/platforms/drone-ci.mdx
@@ -30,6 +30,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Single staged
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 kind: pipeline
 name: default
@@ -38,7 +40,7 @@ steps:
   - name: prepare
     image: alpine:latest
     commands:
-      - curl -fsSL https://pkg.phase.dev/install.sh | bash
+      - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
       - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
   - name: build_and_push

--- a/src/pages/integrations/platforms/github-actions.mdx
+++ b/src/pages/integrations/platforms/github-actions.mdx
@@ -329,6 +329,8 @@ For detailed CLI installation options, please see: [Installation](/cli/install)
 
 ### Single stage
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases). The install script self-elevates when needed, so `sudo` isn't required.
+
 ```yaml
 name: CI
 
@@ -343,7 +345,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install phase-cli
-        run: curl -fsSL https://pkg.phase.dev/install.sh | sudo bash
+        run: curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
 
       - name: Export and set environment variables
         env:

--- a/src/pages/integrations/platforms/gitlab-ci.mdx
+++ b/src/pages/integrations/platforms/gitlab-ci.mdx
@@ -196,6 +196,8 @@ For detailed CLI install options, please see: [Installation](/cli/install)
 
 ### Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 stages:
   - prepare
@@ -204,7 +206,7 @@ stages:
 prepare_phase_cli:
   stage: prepare
   script:
-    - curl -fsSL https://pkg.phase.dev/install.sh | bash
+    - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
     - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
 build_and_push_image:

--- a/src/pages/integrations/platforms/teamcity.mdx
+++ b/src/pages/integrations/platforms/teamcity.mdx
@@ -34,14 +34,14 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 Create a TeamCity build configuration and add the following build steps:
 
-Create a TeamCity build configuration and add the following build steps:
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
 
 1. **Prepare (Command Line Runner)**:
 
    - Run: `Custom script`
    - Custom script:
      ```fish
-     curl -fsSL https://pkg.phase.dev/install.sh | bash
+     curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
      export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
      ```
 

--- a/src/pages/integrations/platforms/travis-ci.mdx
+++ b/src/pages/integrations/platforms/travis-ci.mdx
@@ -31,6 +31,8 @@ For detailed cli install options, please see: [Installation](/cli/install)
 
 ## Example:
 
+Pin the CLI to a specific version with the `--version` flag for reproducible builds — find the latest version on the [Phase CLI releases page](https://github.com/phasehq/cli/releases).
+
 ```yaml
 language: minimal
 
@@ -38,7 +40,7 @@ jobs:
   include:
     - stage: prepare
       script:
-        - curl -fsSL https://pkg.phase.dev/install.sh | bash
+        - curl -fsSL https://pkg.phase.dev/install.sh | sh -s -- --version <X.XX.XX>
         - export $(phase secrets export --app "my application name" --env prod DOCKERHUB_USERNAME DOCKERHUB_TOKEN | xargs)
 
     - stage: build_and_push

--- a/src/pages/quickstart.mdx
+++ b/src/pages/quickstart.mdx
@@ -39,7 +39,7 @@ brew install phasehq/cli/phase
 ```
 
 ```fish {{ title: 'Linux' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'Scoop' }}
@@ -58,7 +58,7 @@ scoop install phase
 ```
 
 ```fish {{ title: 'Alpine Linux' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'NixOS' }}
@@ -77,11 +77,11 @@ docker run phasehq/cli
 ```
 
 ```fish {{ title: 'Raspberry Pi' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 ```fish {{ title: 'ARM64' }}
-curl -fsSL https://pkg.phase.dev/install.sh | bash
+curl -fsSL https://pkg.phase.dev/install.sh | sh
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Improves the CLI install steps in the CI/CD integration guides to make them more consistent — pins the CLI to a specific `--version` and links to the releases page.