### PR TITLE
fix: overflow on narrow and mobile screens

### DIFF
--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -32,7 +32,7 @@ function Eyebrow({ tag, label }) {
         <span className="h-0.5 w-0.5 rounded-full bg-zinc-300 dark:bg-zinc-600" />
       )}
       {label && (
-        <span className="font-mono text-xs text-zinc-400">{label}</span>
+        <span className="min-w-0 font-mono text-xs text-zinc-400">{label}</span>
       )}
     </div>
   )

--- a/src/components/mdx.jsx
+++ b/src/components/mdx.jsx
@@ -44,7 +44,7 @@ export function Note({ children }) {
   return (
     <div className="my-6 flex gap-2.5 rounded-2xl border border-emerald-500/20 bg-emerald-50/50 p-4 leading-6 text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/5 dark:text-emerald-200 dark:[--tw-prose-links:theme(colors.white)] dark:[--tw-prose-links-hover:theme(colors.emerald.300)]">
       <InfoIcon className="mt-1 h-4 w-4 flex-none fill-emerald-500 stroke-white dark:fill-emerald-200/20 dark:stroke-emerald-200" />
-      <div className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
+      <div className="min-w-0 [&>:first-child]:mt-0 [&>:last-child]:mb-0">
         {children}
       </div>
     </div>
@@ -55,7 +55,7 @@ export function Warning({ children }) {
   return (
     <div className="my-6 flex gap-2.5 rounded-2xl border border-red-500/20 bg-red-50/50 p-4 leading-6 text-red-900 dark:border-red-500/30 dark:bg-red-500/5 dark:text-red-200 dark:[--tw-prose-links:theme(colors.white)] dark:[--tw-prose-links-hover:theme(colors.red.300)]">
       <InfoIcon className="mt-1 h-4 w-4 flex-none fill-red-500 stroke-white dark:fill-red-200/20 dark:stroke-red-200" />
-      <div className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
+      <div className="min-w-0 [&>:first-child]:mt-0 [&>:last-child]:mb-0">
         {children}
       </div>
     </div>
@@ -101,7 +101,7 @@ export function Property({ name, type, children }) {
     <li className="m-0 px-0 py-4 first:pt-0 last:pb-0">
       <dl className="m-0 flex flex-wrap items-center gap-x-3 gap-y-2">
         <dt className="sr-only">Name</dt>
-        <dd>
+        <dd className="min-w-0">
           <code>{name}</code>
         </dd>
         <dt className="sr-only">Type</dt>

--- a/src/components/mdx.jsx
+++ b/src/components/mdx.jsx
@@ -125,6 +125,14 @@ export const img = function Img(props) {
   return <ZoomableImage {...props} width={props.width || 800} height={props.height || 600} />
 }
 
+export const table = function Table(props) {
+  return (
+    <div className="overflow-x-auto">
+      <table {...props} />
+    </div>
+  )
+}
+
 export const p = function P({ children, ...rest }) {
   const arr = Array.isArray(children) ? children : [children]
   const meaningful = arr.filter(

--- a/typography.js
+++ b/typography.js
@@ -41,6 +41,7 @@ module.exports = ({ theme }) => ({
       color: 'var(--tw-prose-body)',
       fontSize: theme('fontSize.sm')[0],
       lineHeight: theme('lineHeight.7'),
+      overflowWrap: 'break-word',
 
       // Layout
       '> *': {
@@ -214,6 +215,10 @@ module.exports = ({ theme }) => ({
       'img, video, figure': {
         marginTop: theme('spacing.8'),
         marginBottom: theme('spacing.8'),
+        maxWidth: `min(100%, ${theme('maxWidth.2xl')})`,
+        '@screen lg': {
+          maxWidth: `min(100%, ${theme('maxWidth.3xl')})`,
+        },
       },
       'figure > *': {
         marginTop: '0',


### PR DESCRIPTION
Fixes the overflow behavior for tables, videos, headings and other elements that caused content to get narrowed

## Before

<img width="480" height="986" alt="Screenshot From 2026-08-06 15-29-07" src="https://github.com/user-attachments/assets/b7a90c9b-6f61-4dfa-be60-1ad6605c55e2" />

## After

<img width="480" height="986" alt="Screenshot From 2026-08-06 15-29-23" src="https://github.com/user-attachments/assets/12ae08a3-9416-4289-accb-bfd2396faf0b" />

